### PR TITLE
HOCS-2174 Peg JDK version explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/openjdk11
+FROM quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
 
 ENV USER user_hocs_docs
 ENV USER_ID 1000


### PR DESCRIPTION
The latest version of the upstream image is CentOS 8.
This pegs it to the version used elsewhere (HOCS-2128).