### PR TITLE
HOCS-2647: change depends_on

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,8 @@ steps:
       DOCKER_PASSWORD:
         from_secret: QUAY_ROBOT_TOKEN
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
-    depends_on: []
+    depends_on:
+      - clone
 
   - name: build & push latest
     image: plugins/docker
@@ -33,7 +34,8 @@ steps:
     when:
       branch:
         - main
-    depends_on: []
+    depends_on:
+      - clone
 
 trigger:
   event:


### PR DESCRIPTION
Currently `depends_on: []` doesn't run the steps in parallel. Changing 
this to `depends_on: clone` will run this after the initial.